### PR TITLE
Support empty media info fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ $ cp obs_media_plugin.so /usr/share/obs/obs-plugins/
 ## TODO
 
 - [ ] Handle different artwork ratio (ex: Youtube videos)
-- [ ] Handle missing artwork (or partial info in general)
 - [ ] Not relying on ffmpeg to download images files (linux)
 - [ ] Build using cmake like others obs plugins
 
 ## Note
 
-* If using Firefox make sure `media.hardwaremediakeys.enabled` is set to `true` (default)
+* If you are using Firefox for media playback, make sure `media.hardwaremediakeys.enabled` is set to `true` (default)


### PR DESCRIPTION
**BIG DISCLAIMER:** I am not a C developer! Please triple-check my code!
(This might resolve the "Handle missing artwork (or partial info in general)" TODO point.)

I built the plugin for myself on Linux and noticed it was behaving oddly when switching to a track that didn't have an artist, album or album art set. Otherwise it works quite alright so far - with the exception of it not picking up on VLC stopping the playback (pausing works fine).

I've made these changes such that empty info would not cause the previous info to be carried over to the currently playing track. Might not be ideal - I'm not a C programmer - but it appears I've got it working. Changes in `obs_media_info.c` are to make sure that the album art is unset (and freed) when moving to a track that doesn't have art.